### PR TITLE
Remove duplicated link

### DIFF
--- a/Stuff We Like.md
+++ b/Stuff We Like.md
@@ -20,5 +20,3 @@
 - Netflix Tech Blog - https://medium.com/netflix-techblog
 - Changing Bits - http://blog.mikemccandless.com/
 - The Changelog - https://changelog.com/
-- dev.to/catawiki - https://dev.to/catawiki
-


### PR DESCRIPTION
#### Description

The link to the `https://dev.to/catawiki` website is mentioned at the top of the list ( line 3 )
Removing the duplicated link