### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @catawiki/development


### PR DESCRIPTION
We need to add CODEOWNERS to our repositories to comply with GitHub security standards defined by the Security Team.

I thought @catawiki/development would be a good choice because it includes all engineers.